### PR TITLE
feat: add frontend skeleton for admin-password

### DIFF
--- a/frontend/components/AdminNavbar.tsx
+++ b/frontend/components/AdminNavbar.tsx
@@ -1,0 +1,33 @@
+import { Button, Row } from "@nextui-org/react";
+import { useRouter } from "next/router";
+import React from "react";
+
+const AdminNavbar: React.FC = () => {
+  const router = useRouter();
+
+  const navigateTo = (path: string) => {
+    router.push(path);
+  };
+
+  const NavButton: React.FC<{ path: string }> = ({ path, children }) => (
+    <Button
+      disabled={router.asPath.endsWith(path)}
+      onClick={() => {
+        navigateTo(path);
+      }}
+    >
+      {children}
+    </Button>
+  );
+
+  return (
+    <Row justify="center">
+      <Button.Group size="sm">
+        <NavButton path="/admin">Administrer</NavButton>
+        <NavButton path="/admin/scan">Scan billett</NavButton>
+      </Button.Group>
+    </Row>
+  );
+};
+
+export default AdminNavbar;

--- a/frontend/components/LoginProvider.tsx
+++ b/frontend/components/LoginProvider.tsx
@@ -1,0 +1,48 @@
+import { Button, Col, Input, Row, Spacer, useInput } from "@nextui-org/react";
+import React, { useEffect, useState } from "react";
+
+const LoginProvider: React.FC = ({ children }) => {
+  const [loggedIn, setLoggedIn] = useState(true);
+  const { value, bindings } = useInput("");
+
+  useEffect(() => {
+    // provide authentication with e.g. oauth
+    if (!localStorage.getItem("utstoken")) setLoggedIn(false);
+    else setLoggedIn(true);
+  }, []);
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    localStorage.setItem("utstoken", value);
+    setLoggedIn(true);
+  };
+
+  return loggedIn ? (
+    <>{children}</>
+  ) : (
+    <Row justify="center" align="center" css={{ height: "100vh" }}>
+      <Col>
+        <Row justify="center">Vennligst skriv passord</Row>
+        <Spacer y={1} />
+        <form onSubmit={handleSubmit}>
+          <Row justify="center" gap={1}>
+            <Input.Password
+              aria-label="passord"
+              {...bindings}
+              placeholder="passord"
+            />
+          </Row>
+          <Spacer y={0.5} />
+          <Row justify="center">
+            <Button size={"sm"} type="submit">
+              Logg in
+            </Button>
+          </Row>
+        </form>
+      </Col>
+    </Row>
+  );
+};
+
+export default LoginProvider;

--- a/frontend/pages/admin/index.tsx
+++ b/frontend/pages/admin/index.tsx
@@ -1,0 +1,17 @@
+import { Row } from "@nextui-org/react";
+import type { NextPage } from "next";
+import AdminNavbar from "../../components/AdminNavbar";
+import LoginProvider from "../../components/LoginProvider";
+
+const AdminPage: NextPage = () => {
+  return (
+    <LoginProvider>
+      <AdminNavbar />
+      <Row css={{ height: "100vh" }} justify="center" align="center">
+        Du er logget inn
+      </Row>
+    </LoginProvider>
+  );
+};
+
+export default AdminPage;

--- a/frontend/pages/admin/scan/index.tsx
+++ b/frontend/pages/admin/scan/index.tsx
@@ -1,0 +1,17 @@
+import { Row } from "@nextui-org/react";
+import type { NextPage } from "next";
+import AdminNavbar from "../../../components/AdminNavbar";
+import LoginProvider from "../../../components/LoginProvider";
+
+const AdminPage: NextPage = () => {
+  return (
+    <LoginProvider>
+      <AdminNavbar />
+      <Row css={{ height: "100vh" }} justify="center" align="center">
+        Scan
+      </Row>
+    </LoginProvider>
+  );
+};
+
+export default AdminPage;


### PR DESCRIPTION
Created a `LoginProvider` wrapper which prompts a password within any admin page. There's also has a suggestion for the navigation between admin-pages with `useRoute`.